### PR TITLE
Varun/few fixes

### DIFF
--- a/refill-style.yaml
+++ b/refill-style.yaml
@@ -1231,14 +1231,6 @@ styles:
                                     color.rgb,
                                     step(.5,dot(vec3(0., 0., 1.), worldNormal())));
 
-    rock:
-        base: polygons
-        material:
-            diffuse:
-                texture: images/building-grid.gif
-                mapping: planar
-                scale: .001
-
 
     building-lines:
         base: lines

--- a/refill-style.yaml
+++ b/refill-style.yaml
@@ -2608,8 +2608,7 @@ layers:
                     $zoom: { max: 15 }
                 draw:
                     lines:
-                        order:
-                            order: 351
+                        order: 351
                         outline:
                             order: 350
             pedestrian:
@@ -3997,7 +3996,7 @@ layers:
                     text-blend-order:
                         priority: 6
                         font:
-                            size: [[2,11px],[6,15px],[8,18px],[10,20px],[12,20x],[13,0px]]
+                            size: [[2,11px],[6,15px],[8,18px],[10,20px],[12,20px],[13,0px]]
                 capital:
                     filter: { country_capital: true, $zoom: { min: 5 } }
                     draw:


### PR DESCRIPTION
Couple of small fixes in  	1a20f00.

I took out the `rock` style which was not used in any of the themes or the uber refill file. This style was failing shader compilation on ES, (I am not sure why, a quick look did not reveal anything odd), but since this is not used, I would like to take this out.

Once we start using this style, and if it still fails shader compilation on ES, will investigate this more.

cc. @nvkelso 