### PR TITLE
goodbye mix: hello mix: global.sdk_icon_color_style

### DIFF
--- a/refill-style.yaml
+++ b/refill-style.yaml
@@ -11,9 +11,9 @@
 #
 
 import:
-    - themes/label-5.yaml
-    # the icon import also imports theme/color-black.yaml for us
     - themes/refill-icons.yaml
+    - themes/color-black.yaml
+    - themes/label-5.yaml
 
 global:
     # Sign up for a Mapzen API key to enjoy higher rate limits

--- a/refill-style.yaml
+++ b/refill-style.yaml
@@ -11,8 +11,8 @@
 #
 
 import:
-    - themes/color-black.yaml
     - themes/label-5.yaml
+    # the icon import also imports theme/color-black.yaml for us
     - themes/refill-icons.yaml
 
 global:

--- a/themes/color-black.yaml
+++ b/themes/color-black.yaml
@@ -13,8 +13,10 @@ global:
     transparent:                [0.900,0.900,0.900,0.250]
     route_line:                 [0.000,0.500,1.000]
 
-styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons

--- a/themes/color-blue-gray.yaml
+++ b/themes/color-blue-gray.yaml
@@ -24,6 +24,14 @@ global:
     two_color_ultralight: [0.915,0.928,0.932]
     two_color_offwhite: [0.951,0.955,0.960]
 
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons
+
 layers:
     water:
         draw:
@@ -224,11 +232,6 @@ layers:
                     color: global.two_color_offwhite
 
 styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
-
     railway_dash:
         base: lines
         dash: [0.25, 1.0]

--- a/themes/color-blue.yaml
+++ b/themes/color-blue.yaml
@@ -13,8 +13,10 @@ global:
     transparent:                [0.805,0.871,0.970,0.250] # lighter color at 50%
     route_line:                 [0.502,0.200,0.671]
 
-styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons

--- a/themes/color-brown-orange.yaml
+++ b/themes/color-brown-orange.yaml
@@ -24,6 +24,13 @@ global:
     two_color_ultralight: [1.000,0.922,0.878]
     two_color_offwhite: [1.000,0.965,0.949]
 
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons
 
 layers:
     water:
@@ -225,11 +232,6 @@ layers:
                     color: global.two_color_ultralight
 
 styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
-
     railway_dash:
         base: lines
         dash: [0.25, 1.0]

--- a/themes/color-gray-gold.yaml
+++ b/themes/color-gray-gold.yaml
@@ -24,6 +24,13 @@ global:
     two_color_ultralight:       [0.734,0.647,0.497]
     two_color_offwhite:         [0.815,0.718,0.552]
 
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons
 
 layers:
     water:
@@ -301,12 +308,6 @@ styles:
         shaders:
             defines:
                 COLOR1: vec3(0.153,0.157,0.161)
-
-styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
 
 textures:
     building-grid:

--- a/themes/color-gray.yaml
+++ b/themes/color-gray.yaml
@@ -13,8 +13,10 @@ global:
     transparent:                [0.929,0.929,0.929,0.250]
     route_line:                 [0.313,0.482,0.580]
 
-styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons

--- a/themes/color-high-contrast.yaml
+++ b/themes/color-high-contrast.yaml
@@ -17,6 +17,13 @@ global:
     hi_contrast_midlight:         [0.500,0.500,0.500]
     hi_contrast_offwhite:         [0.980,0.980,0.980]
 
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons
 
     # FILTER
     landuse-casing:
@@ -186,11 +193,6 @@ layers:
 
 
 styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
-
     building-grid:
         shaders:
             uniforms:

--- a/themes/color-inverted.yaml
+++ b/themes/color-inverted.yaml
@@ -13,6 +13,14 @@ global:
     transparent:                [0.800,0.800,0.800,0.250]
     route_line:                 [0.000,0.500,1.000]
 
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons
+
 layers:
     water:
         draw:
@@ -214,11 +222,6 @@ layers:
 
 
 styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
-
     waves:
         shaders:
             uniforms:

--- a/themes/color-pink-yellow.yaml
+++ b/themes/color-pink-yellow.yaml
@@ -24,6 +24,13 @@ global:
     two_color_ultralight: [1.000,0.980,0.850]
     two_color_offwhite: [1.000,0.992,0.940]
 
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons
 
 layers:
     water:
@@ -225,11 +232,6 @@ layers:
                     color: global.two_color_lightest
 
 styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
-
     railway_dash:
         base: lines
         dash: [0.25, 1.0]

--- a/themes/color-pink.yaml
+++ b/themes/color-pink.yaml
@@ -13,8 +13,10 @@ global:
     transparent:               [1.000,0.880,0.972,0.250]
     route_line:                [0.369,0.349,0.729]
 
-styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons

--- a/themes/color-purple-green.yaml
+++ b/themes/color-purple-green.yaml
@@ -25,6 +25,13 @@ global:
     two_color_offwhite:         [0.569,0.431,0.824]
     two_color_white:            [0.690,0.524,1.000]
 
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons
 
 layers:
     water:
@@ -212,11 +219,6 @@ layers:
 
 
 styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
-
     railway_dash:
         base: lines
         dash: [0.25, 1.0]

--- a/themes/color-sepia.yaml
+++ b/themes/color-sepia.yaml
@@ -13,8 +13,10 @@ global:
     transparent:                  [0.940,0.868,0.855,0.250]
     route_line:                   [0.700,0.196,0.507]
 
-styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons

--- a/themes/color-zinc.yaml
+++ b/themes/color-zinc.yaml
@@ -25,6 +25,14 @@ global:
     lightest_gray_color:        [0.800,0.800,0.800]
     gray_offwhite_color:        [0.898,0.898,0.898]
 
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons
+
 scene:
     background:
         color: global.lighter_gray_color
@@ -616,11 +624,6 @@ layers:
 
 
 styles:
-    mapzen_icon_library:
-        # To make Refill's colorize-able icons play nice with other styles
-        # restate the mix so the order of import matters
-        mix: colorized-icons
-
     no_waves:
         base: polygons
 

--- a/themes/refill-icons.yaml
+++ b/themes/refill-icons.yaml
@@ -1,8 +1,21 @@
-import:
-    # Importing the color theme here provides access to
-    # global colors like black_color, white_color, and dark_color; and
-    # to globals like sdk_icon_color_style, icon_size, and text_font_family
-    - color-black.yaml
+global:
+    # To allow standalone icon use let's define core terms that
+    # are otherwise defined in the root {style}-style.yaml,
+    # themes/color-{theme}.yaml or themes/label-{step} files.
+    # This also means {style}-icons.yaml should be imported first.
+    icon_size:          [[13, '14px'], [16, '18px'], [18, '19px']]
+    text_font_family:   'Open Sans'
+    black_color:        [0.00,0.00,0.00]
+    dark_color:         [0.250,0.250,0.250]
+    white_color:        [1.00,1.00,1.00]
+
+    # To make Refill's colorize-able icons play nice with other styles
+    # we re-state the global here in the Refill color theme to use colorized_icons.
+    # This allows the Refill color theme to import *after* say Walkabout icons
+    # and then colorize Walkabout's icons. But when imported before Walkabout icons
+    # then Walkabout icons would not be colorized as Walkabout icons re-set the
+    # global to "" (null).
+    sdk_icon_color_style: colorized_icons
 
 styles:
     mapzen_icon_library:

--- a/themes/refill-icons.yaml
+++ b/themes/refill-icons.yaml
@@ -1,9 +1,17 @@
+global:
+    # To make Refill's colorize-able icons play nice with other styles.
+    # Other styles default to "" or null (don't color).
+    # Here we default Refill to use colorized icons by default by
+    # setting sdk_icon_color_style property value to "colorized-icons"
+    sdk_icon_color_style: colorized_icons
+
 styles:
     mapzen_icon_library:
         base: points
         texture: mapzen_icon_library
         blend_order: 1
-        mix: colorized-icons
+        # To make Refill's colorize-able icons play nice with other styles
+        mix: global.sdk_icon_color_style
         draw:
             size: global.icon_size
             sprite: function() { return feature.kind; }
@@ -20,7 +28,7 @@ styles:
                     size: [[13, 10px], [14, 11px], [17, 12px], [19, 12px], [20, 14px]]
                     stroke: { color: global.white_color, width: [[12,2px],[16,4px]] }
 
-    colorized-icons:
+    colorized_icons:
         shaders:
             uniforms:
                 u_tint: global.black_color

--- a/themes/refill-icons.yaml
+++ b/themes/refill-icons.yaml
@@ -1,9 +1,8 @@
-global:
-    # To make Refill's colorize-able icons play nice with other styles.
-    # Other styles default to "" or null (don't color).
-    # Here we default Refill to use colorized icons by default by
-    # setting sdk_icon_color_style property value to "colorized-icons"
-    sdk_icon_color_style: colorized_icons
+import:
+    # Importing the color theme here provides access to
+    # global colors like black_color, white_color, and dark_color; and
+    # to globals like sdk_icon_color_style, icon_size, and text_font_family
+    - themes/color-black.yaml
 
 styles:
     mapzen_icon_library:

--- a/themes/refill-icons.yaml
+++ b/themes/refill-icons.yaml
@@ -2,7 +2,7 @@ import:
     # Importing the color theme here provides access to
     # global colors like black_color, white_color, and dark_color; and
     # to globals like sdk_icon_color_style, icon_size, and text_font_family
-    - themes/color-black.yaml
+    - color-black.yaml
 
 styles:
     mapzen_icon_library:


### PR DESCRIPTION
Per discussion in https://github.com/tangrams/refill-style/issues/74 this PR:

- Removes from color themes the earlier
  `styles: { mapzen_icon_library: { mix: * } }` logic
- Replaces color themes logic with newer, more generic 
  `global: { sdk_icon_color_style: colorized_icons }`
- Renames the earlier style `colorized-icons` to `colorized_icons` to use basemap _ underbar convention in refill-icons.yaml.
- Repoints the mix in the refill-icons.yaml styles to new global:
  now: `mapzen_icon_library: { mix: { global.sdk_icon_color_style } }`
  was: `mapzen_icon_library: { mix: { colorized-icons } }`
- Adds new default global `sdk_icon_color_style: colorized_icons` to each color theme file
- Switch to setting some basic icon style related globals into `refill-icons.yaml` for standalone imports and standalone recoloring. This impacts import order of operations, which was already true.